### PR TITLE
fix: TypeScriptインデックスシグネチャのプロパティアクセスエラーを修正

### DIFF
--- a/src/services/regular-report-notification.service.ts
+++ b/src/services/regular-report-notification.service.ts
@@ -374,7 +374,10 @@ export class RegularReportNotificationService {
         if (h.data && h.data['topHobbies'] && Array.isArray(h.data['topHobbies'])) {
           (h.data['topHobbies'] as any[]).forEach((hobby: any) => {
             if (hobby && typeof hobby === 'object' && 'name' in hobby) {
-              hobbyCount[hobby.name] = (hobbyCount[hobby.name] || 0) + 1;
+              const hobbyData = hobby as Record<string, unknown>;
+              if (typeof hobbyData['name'] === 'string') {
+                hobbyCount[hobbyData['name'] as string] = (hobbyCount[hobbyData['name'] as string] || 0) + 1;
+              }
             }
           });
         }


### PR DESCRIPTION
## Summary
- regular-report-notification.service.tsでTypeScriptのTS4111エラーを修正
- インデックスシグネチャのプロパティアクセスをドット記法からブラケット記法に変更

## 変更内容
- `hobbyData.name` → `hobbyData['name']`に修正
- TypeScriptコンパイルエラー（TS4111）を解消
- ビルドが正常に通ることを確認済み

## Test plan
- [x] `npm run build`でビルドが成功することを確認
- [x] TypeScriptエラーが解消されることを確認