### PR TITLE
fix: ESLintルールを調整してアンダースコアプレフィックス変数を許可

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -19,6 +19,12 @@ export default tseslint.config([
       ecmaVersion: 2020,
       globals: globals.browser,
     },
+    rules: {
+      '@typescript-eslint/no-unused-vars': ['error', {
+        argsIgnorePattern: '^_',
+        varsIgnorePattern: '^_',
+      }],
+    },
   },
   // テストファイル向けの緩和された設定
   {

--- a/src/services/database.service.ts
+++ b/src/services/database.service.ts
@@ -193,7 +193,6 @@ export class DatabaseService {
         // 趣味をインポート
         if (data.hobbies && Array.isArray(data.hobbies)) {
             for (const hobby of data.hobbies) {
-                // eslint-disable-next-line @typescript-eslint/no-unused-vars
                 const { id: _id, ...hobbyData } = hobby;
                 await this.createHobby(hobbyData);
             }
@@ -202,7 +201,6 @@ export class DatabaseService {
         // 場所をインポート
         if (data.locations && Array.isArray(data.locations)) {
             for (const location of data.locations) {
-                // eslint-disable-next-line @typescript-eslint/no-unused-vars
                 const { id: _id, ...locationData } = location;
                 await this.saveLocation(locationData);
             }
@@ -210,7 +208,6 @@ export class DatabaseService {
 
         // 設定をインポート
         if (data.settings) {
-            // eslint-disable-next-line @typescript-eslint/no-unused-vars
             const { id: _id2, ...settingsData } = data.settings;
             await this.updateSettings(settingsData);
         }


### PR DESCRIPTION
## 概要
database.service.tsの未使用変数Lintエラーを解決しました。

## 変更内容

### ESLint設定の拡張 ([eslint.config.js](../blob/feature/issue-41/eslint.config.js))
```javascript
rules: {
  '@typescript-eslint/no-unused-vars': ['error', {
    argsIgnorePattern: '^_',
    varsIgnorePattern: '^_',
  }],
}
```

### database.service.tsの修正
以下の3箇所から`eslint-disable`コメントを削除:
- 196行目: 趣味インポート時の`_id`変数
- 204行目: 場所インポート時の`_id`変数
- 211行目: 設定インポート時の`_id2`変数

## 修正方針
Issue #41で提案された「オプション3: ESLint設定を調整」を採用しました。
アンダースコアプレフィックスは、TypeScriptコミュニティで広く使用されている
「意図的に未使用の変数」を示す慣習です。

## 品質チェック結果
```
✅ Lint: 0エラー、14警告（既存のReact Hooks警告のみ）
```

## 影響範囲
- database.service.tsのimportData関数
- プロジェクト全体のESLint設定（アンダースコアプレフィックス変数が許可される）

Closes #41