### PR TITLE
fix: TypeScriptビルドエラーを修正 #48

### DIFF
--- a/src/data/database.ts
+++ b/src/data/database.ts
@@ -120,7 +120,7 @@ export class HobbyWeatherDatabase extends Dexie {
     });
 
     this.hobbies.hook('updating', (modifications) => {
-      (modifications as Record<string, unknown>).updatedAt = new Date();
+      (modifications as Record<string, unknown>)['updatedAt'] = new Date();
     });
 
     this.locations.hook('creating', (_, obj) => {
@@ -132,7 +132,7 @@ export class HobbyWeatherDatabase extends Dexie {
     });
 
     this.settings.hook('updating', (modifications) => {
-      (modifications as Record<string, unknown>).updatedAt = new Date();
+      (modifications as Record<string, unknown>)['updatedAt'] = new Date();
     });
 
     this.notificationConfigs.hook('creating', (_, obj) => {
@@ -141,7 +141,7 @@ export class HobbyWeatherDatabase extends Dexie {
     });
 
     this.notificationConfigs.hook('updating', (modifications) => {
-      (modifications as Record<string, unknown>).updatedAt = new Date();
+      (modifications as Record<string, unknown>)['updatedAt'] = new Date();
     });
 
     this.notificationSettings.hook('creating', (_, obj) => {
@@ -149,7 +149,7 @@ export class HobbyWeatherDatabase extends Dexie {
     });
 
     this.notificationSettings.hook('updating', (modifications) => {
-      (modifications as Record<string, unknown>).updatedAt = new Date();
+      (modifications as Record<string, unknown>)['updatedAt'] = new Date();
     });
   }
 

--- a/src/services/api-key-test.ts
+++ b/src/services/api-key-test.ts
@@ -35,7 +35,7 @@ export async function checkWeatherServiceApiKey() {
     const { weatherService } = await import('./weather.service');
     
     // プライベートプロパティにアクセスできるように型キャスト
-    const service = weatherService as { apiKey?: string };
+    const service = weatherService as unknown as { apiKey?: string };
     
     console.log('WeatherService apiKey:', service.apiKey);
     console.log('WeatherService apiKey type:', typeof service.apiKey);
@@ -149,7 +149,7 @@ export async function runDiagnostics() {
     environment: envCheck,
     weatherService: serviceCheck,
     apiConnection: connectionCheck,
-    recommendations: []
+    recommendations: [] as string[]
   };
   
   // 推奨事項の生成
@@ -183,7 +183,7 @@ export async function runDiagnostics() {
   }
   
   console.log('推奨事項:');
-  results.recommendations.forEach((rec: string) => console.log(rec));
+  results.recommendations.forEach((rec) => console.log(rec));
   
   return results;
 }

--- a/src/services/geolocation.service.test.ts
+++ b/src/services/geolocation.service.test.ts
@@ -26,12 +26,19 @@ describe('GeolocationService', () => {
 
   describe('getCurrentPosition', () => {
     it('should get current position successfully', async () => {
-      const mockPosition = {
+      const mockPosition: GeolocationPosition = {
         coords: {
           latitude: 35.6762,
           longitude: 139.6503,
-          accuracy: 10
-        }
+          accuracy: 10,
+          altitude: null,
+          altitudeAccuracy: null,
+          heading: null,
+          speed: null,
+          toJSON: () => ({})
+        },
+        timestamp: Date.now(),
+        toJSON: () => ({})
       };
 
       mockGeolocation.getCurrentPosition.mockImplementation((successCallback: (position: GeolocationPosition) => void) => {
@@ -46,9 +53,12 @@ describe('GeolocationService', () => {
     });
 
     it('should handle permission denied error', async () => {
-      const mockError = {
+      const mockError: GeolocationPositionError = {
         code: 1,
-        message: 'User denied the request for Geolocation.'
+        message: 'User denied the request for Geolocation.',
+        PERMISSION_DENIED: 1,
+        POSITION_UNAVAILABLE: 2,
+        TIMEOUT: 3
       };
 
       mockGeolocation.getCurrentPosition.mockImplementation((_: (position: GeolocationPosition) => void, errorCallback: (error: GeolocationPositionError) => void) => {
@@ -62,9 +72,12 @@ describe('GeolocationService', () => {
     });
 
     it('should handle position unavailable error', async () => {
-      const mockError = {
+      const mockError: GeolocationPositionError = {
         code: 2,
-        message: 'Position unavailable.'
+        message: 'Position unavailable.',
+        PERMISSION_DENIED: 1,
+        POSITION_UNAVAILABLE: 2,
+        TIMEOUT: 3
       };
 
       mockGeolocation.getCurrentPosition.mockImplementation((_: (position: GeolocationPosition) => void, errorCallback: (error: GeolocationPositionError) => void) => {
@@ -78,9 +91,12 @@ describe('GeolocationService', () => {
     });
 
     it('should handle timeout error', async () => {
-      const mockError = {
+      const mockError: GeolocationPositionError = {
         code: 3,
-        message: 'Timeout expired.'
+        message: 'Timeout expired.',
+        PERMISSION_DENIED: 1,
+        POSITION_UNAVAILABLE: 2,
+        TIMEOUT: 3
       };
 
       mockGeolocation.getCurrentPosition.mockImplementation((_: (position: GeolocationPosition) => void, errorCallback: (error: GeolocationPositionError) => void) => {

--- a/src/services/notification-scheduler.service.ts
+++ b/src/services/notification-scheduler.service.ts
@@ -442,7 +442,9 @@ export class NotificationSchedulerService {
                             activeAlert.severity,
                             activeAlert.alertType,
                             activeAlert.message,
-                            activeAlert.details
+                            activeAlert.details.length > 0
+                                ? { items: activeAlert.details } as Record<string, unknown>
+                                : undefined
                         );
                 } else {
                     // アクティブなアラートがない場合はダミーまたはスキップ

--- a/src/services/weather.service.ts
+++ b/src/services/weather.service.ts
@@ -412,6 +412,7 @@ export class WeatherService {
         amenity?: string;
         shop?: string;
         tourism?: string;
+        leisure?: string;
       };
     }
 

--- a/src/test-utils.tsx
+++ b/src/test-utils.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react-refresh/only-export-components */
 import React from 'react';
-import { render, RenderOptions } from '@testing-library/react';
+import { render, type RenderOptions } from '@testing-library/react';
 import { ThemeProvider } from './contexts/ThemeContext';
 
 const AllTheProviders = ({ children }: { children: React.ReactNode }) => {


### PR DESCRIPTION
## 概要
Issue #48で特定されたTypeScriptビルドエラーを修正し、Vercelデプロイメントを成功させるための修正を実施しました。

## 修正内容

### 1. database.ts (4箇所)
- **問題**: インデックスシグネチャプロパティ`updatedAt`にドット記法でアクセス
- **修正**: ブラケット記法に変更 `.updatedAt` → `['updatedAt']`
- **対象行**: 123, 135, 144, 152

### 2. test-utils.tsx
- **問題**: `RenderOptions`がtype-only importでない
- **修正**: `import { render, type RenderOptions }` に変更
- **対象行**: 3

### 3. api-key-test.ts
- **問題**: 
  - 型キャストの不整合 (line 38)
  - `recommendations`配列の型エラー (lines 152, 186)
- **修正**:
  - `as unknown as` を使用した二段階キャスト
  - `recommendations: [] as string[]` で明示的に型指定
  - `forEach`のコールバック引数から型注釈を削除

### 4. geolocation.service.test.ts
- **問題**: モックオブジェクトに必要なプロパティが不足
- **修正**: 
  - `GeolocationPosition`と`GeolocationCoordinates`に`toJSON`メソッドを追加
  - `GeolocationPositionError`に`PERMISSION_DENIED`, `POSITION_UNAVAILABLE`, `TIMEOUT`プロパティを追加
- **対象行**: 38, 55, 71, 87

### 5. notification-scheduler.service.ts
- **問題**: 配列型の`activeAlert.details`を`Record<string, unknown>`パラメータに渡す型エラー
- **修正**: 配列をオブジェクトにラップ `{ items: activeAlert.details }` または`undefined`に変換
- **対象行**: 445

### 6. weather.service.ts
- **問題**: `LocationWithTags`型の`tags`プロパティに`leisure`が定義されていない
- **修正**: `tags`インターフェースに`leisure?: string;`を追加
- **対象行**: 415

## テスト結果

すべてのコード品質チェックが成功:
- ✅ `npm run typecheck` - TypeScript型チェック成功
- ✅ `npm run lint` - ESLint成功
- ✅ `npm run build` - ビルド成功

## 関連Issue
Closes #48

## 期待される効果
- Vercelデプロイメントが成功するようになる
- TypeScriptの厳格な型チェックに準拠
- 既存機能への影響なし