### PR TITLE
fix: Issue連続改修 (#171 #173 #174 #176 #177 #180 #182 #183 #184 #185 #186 #187 #188 #190)

### DIFF
--- a/src/components/weather/WeatherCard.tsx
+++ b/src/components/weather/WeatherCard.tsx
@@ -233,7 +233,7 @@ export const WeatherCard: React.FC<WeatherCardProps> = ({
                                 視界
                             </p>
                             <p className="text-lg font-semibold text-purple-700">
-                                {(weather.visibility / 1000).toFixed(1)} km
+                                {weather.visibility == null || weather.visibility <= 0 ? 'データなし' : `${(weather.visibility / 1000).toFixed(1)} km`}
                             </p>
                         </div>
                     </div>

--- a/src/components/weather/WeatherDisplay.tsx
+++ b/src/components/weather/WeatherDisplay.tsx
@@ -49,7 +49,7 @@ export const WeatherDisplay: React.FC = () => {
                                 エラーが発生しました
                             </h3>
                             <div className="mt-1 text-sm text-red-700">
-                                {error || locationError}
+                                {[error, locationError].filter(Boolean).join(' / ')}
                             </div>
                             <div className="mt-2">
                                 <button

--- a/src/data/database.ts
+++ b/src/data/database.ts
@@ -154,30 +154,35 @@ export class HobbyWeatherDatabase extends Dexie {
   }
 
   async initializeDefaultData() {
-    const settingsCount = await this.settings.count();
-    if (settingsCount === 0) {
-      await this.settings.add({
-        temperatureUnit: 'celsius',
-        windSpeedUnit: 'kmh',
-        language: 'ja',
-        notificationsEnabled: true,
-        cacheExpiration: 6,
-        updatedAt: new Date()
-      });
-    }
+    // count チェックと add をトランザクション内でアトミックに実行し、競合状態による重複挿入を防ぐ
+    await this.transaction('rw', this.settings, async () => {
+      const settingsCount = await this.settings.count();
+      if (settingsCount === 0) {
+        await this.settings.add({
+          temperatureUnit: 'celsius',
+          windSpeedUnit: 'kmh',
+          language: 'ja',
+          notificationsEnabled: true,
+          cacheExpiration: 6,
+          updatedAt: new Date()
+        });
+      }
+    });
 
     // デフォルトの通知設定を初期化
-    const notificationSettingsCount = await this.notificationSettings.count();
-    if (notificationSettingsCount === 0) {
-      await this.notificationSettings.add({
-        globalEnabled: true,
-        quietHours: null,
-        maxDailyNotifications: 10,
-        soundEnabled: true,
-        vibrationEnabled: true,
-        updatedAt: new Date()
-      });
-    }
+    await this.transaction('rw', this.notificationSettings, async () => {
+      const notificationSettingsCount = await this.notificationSettings.count();
+      if (notificationSettingsCount === 0) {
+        await this.notificationSettings.add({
+          globalEnabled: true,
+          quietHours: null,
+          maxDailyNotifications: 10,
+          soundEnabled: true,
+          vibrationEnabled: true,
+          updatedAt: new Date()
+        });
+      }
+    });
   }
 
   async clearExpiredCache() {

--- a/src/hooks/useDatabase.ts
+++ b/src/hooks/useDatabase.ts
@@ -20,10 +20,28 @@ export const useDatabase = () => {
   };
 
   useEffect(() => {
-    initialize();
+    let initialized = false;
+
+    const init = async () => {
+      setError(null);
+      setIsInitialized(false);
+      try {
+        await db.open();
+        await db.initializeDefaultData();
+        await db.clearExpiredCache();
+        initialized = true;
+        setIsInitialized(true);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Database initialization failed');
+      }
+    };
+
+    init();
 
     return () => {
-      db.close();
+      if (initialized) {
+        db.close();
+      }
     };
   }, []);
 

--- a/src/hooks/useHobby.ts
+++ b/src/hooks/useHobby.ts
@@ -102,14 +102,19 @@ export const useHobby = (): UseHobbyReturn => {
   }, [updateState, loadHobbies]);
 
   const toggleHobbyActive = useCallback(async (id: number) => {
-    const hobby = state.hobbies.find(h => h.id === id);
+    let hobby: Hobby | undefined;
+    setState(prev => {
+      hobby = prev.hobbies.find(h => h.id === id);
+      return prev;
+    });
+
     if (!hobby) {
       updateState({ error: '趣味が見つかりません' });
       return;
     }
 
     await updateHobby(id, { isActive: !hobby.isActive });
-  }, [state.hobbies, updateHobby, updateState]);
+  }, [updateHobby, updateState]);
 
   const refreshHobbies = useCallback(async () => {
     await loadHobbies();

--- a/src/hooks/useInitialSetup.ts
+++ b/src/hooks/useInitialSetup.ts
@@ -84,6 +84,13 @@ export const useInitialSetup = () => {
     });
   }, [hobbies, location, hobbiesLoading, weatherLoading]);
 
+  // ローディング状態を同期的に反映
+  useEffect(() => {
+    if (hobbiesLoading || weatherLoading) {
+      setSetupState(prev => ({ ...prev, isLoading: true }));
+    }
+  }, [hobbiesLoading, weatherLoading]);
+
   // 初期化時とデータ変更時に設定状態を更新
   useEffect(() => {
     if (!hobbiesLoading && !weatherLoading) {

--- a/src/hooks/useNotificationConfig.ts
+++ b/src/hooks/useNotificationConfig.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useMemo } from 'react';
+import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { NotificationConfigService } from '../services/notification-config.service';
 import type {
   NotificationConfig,
@@ -36,29 +36,38 @@ export function useNotificationConfig(): UseNotificationConfigReturn {
   const [error, setError] = useState<string | null>(null);
 
   const configService = useMemo(() => new NotificationConfigService(), []);
+  // loadData の呼び出し順を追跡するカウンター。最新の呼び出しのみ state を更新する
+  const loadSeqRef = useRef(0);
 
   // 初期データの読み込み
   const loadData = useCallback(async () => {
+    const seq = ++loadSeqRef.current;
     try {
       setIsLoading(true);
       setError(null);
-      
+
       const [configsData, settingsData, historyData] = await Promise.all([
         configService.getAllNotificationConfigs(),
         configService.getNotificationSettings(),
         configService.getNotificationHistory({ limit: 50 }) // 最新50件
       ]);
-      
+
+      // 自分より後に呼ばれた loadData がある場合は古い結果を捨てる
+      if (seq !== loadSeqRef.current) return;
+
       setConfigs(configsData);
       setSettings(settingsData || null);
       setHistory(historyData);
     } catch (err) {
+      if (seq !== loadSeqRef.current) return;
       setError(err instanceof Error ? err.message : '通知設定の読み込みに失敗しました');
       if (import.meta.env.DEV) {
         console.error('通知設定読み込みエラー:', err);
       }
     } finally {
-      setIsLoading(false);
+      if (seq === loadSeqRef.current) {
+        setIsLoading(false);
+      }
     }
   }, [configService]);
 

--- a/src/hooks/useNotificationScheduler.ts
+++ b/src/hooks/useNotificationScheduler.ts
@@ -29,15 +29,14 @@ export function useNotificationScheduler(): UseNotificationSchedulerReturn {
   const [error, setError] = useState<string | null>(null);
 
   const schedulerRef = useRef(NotificationSchedulerService.getInstance());
-  const scheduler = schedulerRef.current;
 
   // スケジューラー状態の更新
   const updateStatus = useCallback(() => {
     try {
-      const status = scheduler.getStatus();
+      const status = schedulerRef.current.getStatus();
       setIsRunning(status.isRunning);
       setTaskCount(status.taskCount);
-      
+
       if (status.nextTask) {
         setNextTask({
           id: status.nextTask.id,
@@ -51,7 +50,7 @@ export function useNotificationScheduler(): UseNotificationSchedulerReturn {
         setNextTask(null);
       }
 
-      const currentTasks = scheduler.getCurrentTasks();
+      const currentTasks = schedulerRef.current.getCurrentTasks();
       setAllTasks(currentTasks.map(task => ({
         id: task.id,
         configId: task.configId,
@@ -65,29 +64,29 @@ export function useNotificationScheduler(): UseNotificationSchedulerReturn {
     } catch (err) {
       setError(err instanceof Error ? err.message : 'スケジューラー状態の取得に失敗');
     }
-  }, [scheduler]);
+  }, []);
 
   // スケジューラーの開始
   const start = useCallback(async () => {
     try {
       setError(null);
-      await scheduler.start();
+      await schedulerRef.current.start();
       updateStatus();
     } catch (err) {
       setError(err instanceof Error ? err.message : 'スケジューラーの開始に失敗');
     }
-  }, [scheduler, updateStatus]);
+  }, [updateStatus]);
 
   // スケジューラーの停止
   const stop = useCallback(() => {
     try {
       setError(null);
-      scheduler.stop();
+      schedulerRef.current.stop();
       updateStatus();
     } catch (err) {
       setError(err instanceof Error ? err.message : 'スケジューラーの停止に失敗');
     }
-  }, [scheduler, updateStatus]);
+  }, [updateStatus]);
 
   // 状態の再読み込み
   const refresh = useCallback(() => {

--- a/src/hooks/useRecommendation.ts
+++ b/src/hooks/useRecommendation.ts
@@ -38,18 +38,21 @@ export function useRecommendation(): UseRecommendationState & UseRecommendationA
    * おすすめを生成
    */
   const generateRecommendations = useCallback(async (hobbies: Hobby[], forecast: WeatherForecast, customFilters?: RecommendationFilters) => {
-    let filtersToUse: RecommendationFilters | undefined;
+    let resolvedFilters: RecommendationFilters | undefined;
 
-    setState(prev => {
-      filtersToUse = customFilters !== undefined ? customFilters : prev.filters;
-      return { ...prev, isLoading: true, error: null };
+    await new Promise<void>(resolve => {
+      setState(prev => {
+        resolvedFilters = customFilters !== undefined ? customFilters : prev.filters;
+        resolve();
+        return { ...prev, isLoading: true, error: null };
+      });
     });
 
     try {
       const recommendations = await recommendationService.generateRecommendations(
         hobbies,
         forecast,
-        filtersToUse
+        resolvedFilters
       );
 
       setState(prev => ({
@@ -102,7 +105,10 @@ export function useRecommendation(): UseRecommendationState & UseRecommendationA
    */
   const getRecommendationsForHobby = useCallback((hobbyId: number | string): HobbyRecommendation | undefined => {
     const id = typeof hobbyId === 'string' ? parseInt(hobbyId, 10) : hobbyId;
-    if (typeof id === 'number' && isNaN(id)) return undefined;
+    if (isNaN(id)) {
+      console.warn(`getRecommendationsForHobby: 不正なhobbyId "${hobbyId}" が渡されました。`);
+      return undefined;
+    }
     return state.recommendations.find(rec => rec.hobby.id === id);
   }, [state.recommendations]);
 
@@ -124,10 +130,13 @@ export function useRecommendation(): UseRecommendationState & UseRecommendationA
 
   // フィルター変更時に自動再生成
   useEffect(() => {
-    if (lastParams && !state.isLoading) {
+    if (lastParams) {
       generateRecommendations(lastParams.hobbies, lastParams.forecast, state.filters);
     }
-  }, [state.filters, generateRecommendations, lastParams, state.isLoading]);
+    // generateRecommendationsは依存配列から除外（useCallbackで安定した参照を持つため）
+    // state.isLoadingを依存配列から除外（フィルター変更時のみ再実行するため）
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [state.filters, lastParams]);
 
   return {
     ...state,

--- a/src/hooks/useWeather.ts
+++ b/src/hooks/useWeather.ts
@@ -41,9 +41,10 @@ export const useWeather = (): UseWeatherReturn => {
     updateState({ error: null, locationError: null });
   }, [updateState]);
 
-  const loadDefaultLocation = useCallback(async () => {
+  const loadDefaultLocation = useCallback(async (isCancelled?: () => boolean) => {
     try {
       const defaultLocation = await databaseService.getDefaultLocation();
+      if (isCancelled?.()) return null;
       if (defaultLocation) {
         updateState({ location: defaultLocation });
         return defaultLocation;
@@ -56,7 +57,8 @@ export const useWeather = (): UseWeatherReturn => {
     return null;
   }, [updateState]);
 
-  const fetchWeatherData = useCallback(async (lat: number, lon: number, forceRefresh = false) => {
+  const fetchWeatherData = useCallback(async (lat: number, lon: number, forceRefresh = false, isCancelled?: () => boolean) => {
+    if (isCancelled?.()) return;
     updateState({ isLoading: true, error: null });
 
     try {
@@ -65,12 +67,14 @@ export const useWeather = (): UseWeatherReturn => {
         weatherService.getWeatherForecast(lat, lon, forceRefresh)
       ]);
 
+      if (isCancelled?.()) return;
       updateState({
         currentWeather,
         forecast,
         isLoading: false
       });
     } catch (error) {
+      if (isCancelled?.()) return;
       updateState({
         error: error instanceof Error ? error.message : '天気情報の取得に失敗しました',
         isLoading: false
@@ -118,14 +122,20 @@ export const useWeather = (): UseWeatherReturn => {
 
   const setLocation = useCallback(async (location: Location) => {
     updateState({ location });
-    
-    // まだ設定されていない場合はデフォルトの場所として更新
-    if (!location.isDefault && location.id) {
-      await databaseService.updateLocation(location.id, { isDefault: true });
-    }
 
-    // 新しい場所の天気を取得
-    await fetchWeatherData(location.lat, location.lon, true);
+    try {
+      // まだ設定されていない場合はデフォルトの場所として更新
+      if (!location.isDefault && location.id) {
+        await databaseService.updateLocation(location.id, { isDefault: true });
+      }
+
+      // 新しい場所の天気を取得
+      await fetchWeatherData(location.lat, location.lon, true);
+    } catch (error) {
+      updateState({
+        locationError: error instanceof Error ? error.message : '位置情報の設定に失敗しました'
+      });
+    }
   }, [updateState, fetchWeatherData]);
 
   const refreshWeather = useCallback(async () => {
@@ -137,12 +147,13 @@ export const useWeather = (): UseWeatherReturn => {
   // デフォルトの場所で初期化
   useEffect(() => {
     let cancelled = false;
+    const isCancelled = () => cancelled;
 
     const initialize = async () => {
-      const defaultLocation = await loadDefaultLocation();
+      const defaultLocation = await loadDefaultLocation(isCancelled);
       if (cancelled) return;
       if (defaultLocation) {
-        await fetchWeatherData(defaultLocation.lat, defaultLocation.lon);
+        await fetchWeatherData(defaultLocation.lat, defaultLocation.lon, false, isCancelled);
       }
     };
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -10,7 +10,7 @@ import { registerSW } from 'virtual:pwa-register'
 const updateSW = registerSW({
   onNeedRefresh() {
     if (confirm('新しいバージョンが利用可能です。アプリを再読み込みしますか？')) {
-      updateSW(true).catch(() => {})
+      updateSW(true).catch(console.error)
     }
   },
   onOfflineReady() {


### PR DESCRIPTION
## 修正 Issue 一覧

- Closes #171
- Closes #173
- Closes #174
- Closes #176
- Closes #177
- Closes #180
- Closes #182
- Closes #183
- Closes #184
- Closes #185
- Closes #186
- Closes #187
- Closes #188
- Closes #190

## 修正内容

- #171: visibility null/0以下時に「データなし」表示を追加
- #173: errorとlocationError両方を ' / ' で連結して表示
- #174: useEffect内にinitializedフラグを導入しdb.close()を初期化成功時のみ実行
- #176: initializeDefaultDataをトランザクションでアトミック化し重複挿入を防止
- #177: toggleHobbyActiveをsetState関数形式で最新stateを参照するよう変更
- #180: ローディング中にisLoadingをtrueに同期更新するuseEffectを追加
- #182: schedulerインスタンスをuseRefで固定し参照安定性を確保
- #183: loadDataにシーケンス番号フラグを導入し並走競合状態を修正
- #184: useEffect依存配列からgenerateRecommendationsとstate.isLoadingを除去し無限ループリスクを排除
- #185: generateRecommendationsのstale closureをsetState内でfilters解決するよう修正
- #186: parseInt NaN時にconsole.warn警告を追加
- #187: setLocationをtry-catchで囲みlocationErrorステートを更新
- #188: useWeather初期化でキャンセルフラグを伝播しアンマウント後のstate更新を防止
- #190: updateSW(true).catch(console.error)でエラーを適切に捕捉

## テスト

- ビルド: 全修正後にビルド検証済み（npm run build 成功）