### PR TITLE
fix: Issue連続改修 (#50 #51 #52 #66 #67 #78 #80 #88 #94 #104 #112 #113 #125 #130 #147 #155 #156 #157 #159 #165 #167 #170)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -5,6 +5,8 @@ import reactRefresh from 'eslint-plugin-react-refresh'
 import tseslint from 'typescript-eslint'
 import { globalIgnores } from 'eslint/config'
 
+const IGNORE_PATTERN = '^_';
+
 export default tseslint.config([
   globalIgnores(['dist', '.vite', 'coverage', '*.config.js.timestamp-*']),
   {
@@ -21,8 +23,8 @@ export default tseslint.config([
     },
     rules: {
       '@typescript-eslint/no-unused-vars': ['error', {
-        argsIgnorePattern: '^_',
-        varsIgnorePattern: '^_',
+        argsIgnorePattern: IGNORE_PATTERN,
+        varsIgnorePattern: IGNORE_PATTERN,
       }],
     },
   },
@@ -33,6 +35,12 @@ export default tseslint.config([
       js.configs.recommended,
       tseslint.configs.recommended,
     ],
+    languageOptions: {
+      globals: {
+        ...globals.browser,
+        ...globals.jest,
+      },
+    },
     rules: {
       '@typescript-eslint/no-explicit-any': 'off',
       '@typescript-eslint/no-unused-vars': 'off',

--- a/package.json
+++ b/package.json
@@ -22,6 +22,12 @@
         "test:e2e:report": "playwright show-report",
         "typecheck": "tsc --noEmit"
     },
+    "browserslist": [
+      "> 0.5%",
+      "last 2 versions",
+      "not dead",
+      "not IE 11"
+    ],
     "dependencies": {
         "dexie": "^4.0.11",
         "react": "^19.1.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useCallback, Suspense, lazy } from 'react';
+import React, { useRef, useCallback, Suspense, lazy, Component, type ErrorInfo, type ReactNode } from 'react';
 import { InitialSetupFlow } from './components/setup/InitialSetupFlow';
 import { useInitialSetup } from './hooks/useInitialSetup';
 import { ThemeToggle } from './components/theme/ThemeToggle';
@@ -11,6 +11,38 @@ const HobbyManager = lazy(() => import('./components/hobby/HobbyManager').then(m
 const WeatherDisplay = lazy(() => import('./components/weather/WeatherDisplay').then(module => ({ default: module.WeatherDisplay })));
 const RecommendationDashboard = lazy(() => import('./components/recommendation/RecommendationDashboard').then(module => ({ default: module.RecommendationDashboard })));
 const SettingsPage = lazy(() => import('./components/settings/SettingsPage').then(module => ({ default: module.SettingsPage })));
+
+// チャンク読み込みエラーをキャッチするErrorBoundary
+class LazyErrorBoundary extends Component<
+  { children: ReactNode; fallback?: ReactNode },
+  { hasError: boolean }
+> {
+  constructor(props: { children: ReactNode; fallback?: ReactNode }) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError(_: Error) {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    if (import.meta.env.DEV) {
+      console.error('Lazy load error:', error, info);
+    }
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return this.props.fallback ?? (
+        <div className="flex items-center justify-center py-12 text-text-secondary">
+          <span>コンポーネントの読み込みに失敗しました。ページを再読み込みしてください。</span>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}
 
 // アプリケーションのメインタブ
 type TabType = 'weather' | 'hobbies' | 'recommendations' | 'settings';
@@ -168,9 +200,11 @@ function App() {
                         hidden={activeTab !== 'recommendations'}
                     >
                         {activeTab === 'recommendations' && (
-                            <Suspense fallback={<LoadingSpinner />}>
-                                <RecommendationDashboard />
-                            </Suspense>
+                            <LazyErrorBoundary>
+                                <Suspense fallback={<LoadingSpinner />}>
+                                    <RecommendationDashboard />
+                                </Suspense>
+                            </LazyErrorBoundary>
                         )}
                     </div>
                     <div 
@@ -181,9 +215,11 @@ function App() {
                         hidden={activeTab !== 'weather'}
                     >
                         {activeTab === 'weather' && (
-                            <Suspense fallback={<LoadingSpinner />}>
-                                <WeatherDisplay />
-                            </Suspense>
+                            <LazyErrorBoundary>
+                                <Suspense fallback={<LoadingSpinner />}>
+                                    <WeatherDisplay />
+                                </Suspense>
+                            </LazyErrorBoundary>
                         )}
                     </div>
                     <div 
@@ -194,9 +230,11 @@ function App() {
                         hidden={activeTab !== 'hobbies'}
                     >
                         {activeTab === 'hobbies' && (
-                            <Suspense fallback={<LoadingSpinner />}>
-                                <HobbyManager />
-                            </Suspense>
+                            <LazyErrorBoundary>
+                                <Suspense fallback={<LoadingSpinner />}>
+                                    <HobbyManager />
+                                </Suspense>
+                            </LazyErrorBoundary>
                         )}
                     </div>
                     <div 
@@ -207,9 +245,11 @@ function App() {
                         hidden={activeTab !== 'settings'}
                     >
                         {activeTab === 'settings' && (
-                            <Suspense fallback={<LoadingSpinner />}>
-                                <SettingsPage />
-                            </Suspense>
+                            <LazyErrorBoundary>
+                                <Suspense fallback={<LoadingSpinner />}>
+                                    <SettingsPage />
+                                </Suspense>
+                            </LazyErrorBoundary>
                         )}
                     </div>
                 </div>

--- a/src/components/common/ApiKeyDiagnostics.tsx
+++ b/src/components/common/ApiKeyDiagnostics.tsx
@@ -183,7 +183,9 @@ export const ApiKeyDiagnostics: React.FC = () => {
                 <div className="bg-gray-100 rounded p-3 text-sm font-mono">
                   <p>設定状況: {results.environment.hasApiKey ? '✅ 設定済み' : '❌ 未設定'}</p>
                   <p>キー長: {results.environment.apiKeyLength}文字</p>
-                  <p>プレビュー: {results.environment.apiKeyPreview}</p>
+                  {import.meta.env.DEV && (
+                    <p>プレビュー: {results.environment.apiKeyPreview}</p>
+                  )}
                 </div>
               </div>
 
@@ -193,7 +195,9 @@ export const ApiKeyDiagnostics: React.FC = () => {
                 <div className="bg-gray-100 rounded p-3 text-sm font-mono">
                   <p>読み込み状況: {results.weatherService.hasApiKey ? '✅ 正常' : '❌ エラー'}</p>
                   <p>キー長: {results.weatherService.apiKeyLength}文字</p>
-                  <p>プレビュー: {results.weatherService.apiKeyPreview}</p>
+                  {import.meta.env.DEV && (
+                    <p>プレビュー: {results.weatherService.apiKeyPreview}</p>
+                  )}
                   {results.weatherService.error && (
                     <p className="text-red-600">エラー: {results.weatherService.error}</p>
                   )}

--- a/src/components/hobby/HobbyList.tsx
+++ b/src/components/hobby/HobbyList.tsx
@@ -209,7 +209,7 @@ export const HobbyList: React.FC<HobbyListProps> = ({
 
                             <div className="flex flex-col space-y-2 ml-4">
                                 <button
-                                    onClick={() => onToggleActive(hobby.id!)}
+                                    onClick={() => hobby.id !== undefined && onToggleActive(hobby.id)}
                                     className="px-3 py-1 text-xs font-medium rounded-md transition-opacity hover:opacity-80"
                                     style={{
                                         backgroundColor: hobby.isActive
@@ -246,7 +246,7 @@ export const HobbyList: React.FC<HobbyListProps> = ({
                                                 `「${hobby.name}」を削除しますか？この操作は取り消せません。`
                                             )
                                         ) {
-                                            onDelete(hobby.id!);
+                                            if (hobby.id !== undefined) onDelete(hobby.id);
                                         }
                                     }}
                                     className="px-3 py-1 text-xs font-medium rounded-md transition-opacity hover:opacity-80"

--- a/src/components/hobby/HobbyManager.tsx
+++ b/src/components/hobby/HobbyManager.tsx
@@ -33,8 +33,8 @@ export const HobbyManager: React.FC = () => {
     const handleCreate = async (
         hobbyData: Omit<Hobby, 'id' | 'createdAt' | 'updatedAt'>
     ) => {
-        await createHobby(hobbyData);
-        if (!error) {
+        const success = await createHobby(hobbyData);
+        if (success) {
             setViewMode('list');
         }
     };
@@ -44,8 +44,8 @@ export const HobbyManager: React.FC = () => {
     ) => {
         if (!editingHobby?.id) return;
 
-        await updateHobby(editingHobby.id, hobbyData);
-        if (!error) {
+        const success = await updateHobby(editingHobby.id, hobbyData);
+        if (success) {
             setViewMode('list');
             setEditingHobby(null);
         }

--- a/src/components/notification/NotificationPermissionPrompt.tsx
+++ b/src/components/notification/NotificationPermissionPrompt.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { useNotification } from '../../hooks/useNotification';
 
 interface NotificationPermissionPromptProps {
@@ -6,12 +7,14 @@ interface NotificationPermissionPromptProps {
   className?: string;
 }
 
-export function NotificationPermissionPrompt({ 
-  onPermissionGranted, 
+export function NotificationPermissionPrompt({
+  onPermissionGranted,
   onPermissionDenied,
   className = ""
 }: NotificationPermissionPromptProps) {
   const { permission, isSupported, isLoading, requestPermission, sendTestNotification } = useNotification();
+  const [isSending, setIsSending] = useState(false);
+  const [testMessage, setTestMessage] = useState<{ type: 'success' | 'error'; text: string } | null>(null);
 
   const handleRequestPermission = async () => {
     try {
@@ -29,13 +32,23 @@ export function NotificationPermissionPrompt({
   };
 
   const handleTestNotification = async () => {
+    setIsSending(true);
+    setTestMessage(null);
     try {
       const success = await sendTestNotification();
-      if (!success && import.meta.env.DEV) {
-        console.error('テスト通知の送信に失敗しました');
+      if (success) {
+        setTestMessage({ type: 'success', text: 'テスト通知を送信しました' });
+      } else {
+        setTestMessage({ type: 'error', text: '通知の送信に失敗しました' });
       }
     } catch (error) {
-      console.error('テスト通知の送信中にエラーが発生しました', error);
+      setTestMessage({
+        type: 'error',
+        text: error instanceof Error ? error.message : '予期しないエラーが発生しました'
+      });
+    } finally {
+      setIsSending(false);
+      setTimeout(() => setTestMessage(null), 3000);
     }
   };
 
@@ -72,13 +85,20 @@ export function NotificationPermissionPrompt({
               </p>
             </div>
           </div>
-          <button
-            onClick={handleTestNotification}
-            disabled={isLoading}
-            className="text-sm bg-green-600 text-white px-3 py-1 rounded hover:bg-green-700"
-          >
-            テスト送信
-          </button>
+          <div className="flex flex-col items-end gap-1">
+            <button
+              onClick={handleTestNotification}
+              disabled={isLoading || isSending}
+              className="text-sm bg-green-600 text-white px-3 py-1 rounded hover:bg-green-700 disabled:opacity-50"
+            >
+              {isSending ? '送信中...' : 'テスト送信'}
+            </button>
+            {testMessage && (
+              <span className={`text-xs ${testMessage.type === 'success' ? 'text-green-700' : 'text-red-700'}`}>
+                {testMessage.type === 'success' ? '✅' : '❌'} {testMessage.text}
+              </span>
+            )}
+          </div>
         </div>
       </div>
     );

--- a/src/components/notification/NotificationSettings.tsx
+++ b/src/components/notification/NotificationSettings.tsx
@@ -11,7 +11,30 @@ interface NotificationSettingsProps {
 
 export function NotificationSettings({ className = "" }: NotificationSettingsProps) {
   const { currentTheme } = useTheme();
-  const { permission } = useNotification();
+  const { permission, sendTestNotification } = useNotification();
+  const [isSendingTest, setIsSendingTest] = useState(false);
+  const [testMessage, setTestMessage] = useState<{ type: 'success' | 'error'; text: string } | null>(null);
+
+  const handleTestNotification = async () => {
+    setIsSendingTest(true);
+    setTestMessage(null);
+    try {
+      const result = await sendTestNotification();
+      if (result) {
+        setTestMessage({ type: 'success', text: 'テスト通知を送信しました' });
+      } else {
+        setTestMessage({ type: 'error', text: '通知の送信に失敗しました' });
+      }
+    } catch (error) {
+      setTestMessage({
+        type: 'error',
+        text: error instanceof Error ? error.message : '予期しないエラーが発生しました'
+      });
+    } finally {
+      setIsSendingTest(false);
+      setTimeout(() => setTestMessage(null), 3000);
+    }
+  };
   const { 
     configs, 
     settings, 
@@ -32,6 +55,7 @@ export function NotificationSettings({ className = "" }: NotificationSettingsPro
   const [quietHoursEnabled, setQuietHoursEnabled] = useState(false);
   const [quietStart, setQuietStart] = useState('22:00');
   const [quietEnd, setQuietEnd] = useState('07:00');
+  const [settingsError, setSettingsError] = useState<string | null>(null);
 
   // 設定の初期化
   useEffect(() => {
@@ -55,32 +79,41 @@ export function NotificationSettings({ className = "" }: NotificationSettingsPro
     }
   };
 
+  const safeUpdateSettings = async (patch: Parameters<typeof updateSettings>[0]) => {
+    setSettingsError(null);
+    try {
+      await updateSettings(patch);
+    } catch (e) {
+      setSettingsError(e instanceof Error ? e.message : '設定の更新に失敗しました');
+    }
+  };
+
   // グローバル設定の更新
   const handleGlobalToggle = async (enabled: boolean) => {
-    await updateSettings({ globalEnabled: enabled });
+    await safeUpdateSettings({ globalEnabled: enabled });
   };
 
   // 静寂時間の更新
   const handleQuietHoursChange = async () => {
-    const quietHours: TimeRange | null = quietHoursEnabled 
+    const quietHours: TimeRange | null = quietHoursEnabled
       ? { start: quietStart, end: quietEnd }
       : null;
-    
-    await updateSettings({ quietHours });
+
+    await safeUpdateSettings({ quietHours });
   };
 
   // 最大通知数の更新
   const handleMaxNotificationsChange = async (max: number) => {
-    await updateSettings({ maxDailyNotifications: max });
+    await safeUpdateSettings({ maxDailyNotifications: max });
   };
 
   // 音・振動設定の更新
   const handleSoundToggle = async (enabled: boolean) => {
-    await updateSettings({ soundEnabled: enabled });
+    await safeUpdateSettings({ soundEnabled: enabled });
   };
 
   const handleVibrationToggle = async (enabled: boolean) => {
-    await updateSettings({ vibrationEnabled: enabled });
+    await safeUpdateSettings({ vibrationEnabled: enabled });
   };
 
   if (isLoading) {
@@ -152,6 +185,13 @@ export function NotificationSettings({ className = "" }: NotificationSettingsPro
 
   return (
     <div className={`space-y-6 ${className}`}>
+      {/* 設定更新エラー */}
+      {settingsError && (
+        <div className="border rounded-lg p-3 text-sm" style={{ borderColor: currentTheme.colors.error, color: currentTheme.colors.error }}>
+          {settingsError}
+        </div>
+      )}
+
       {/* 通知許可プロンプト */}
       <NotificationPermissionPrompt />
 
@@ -217,7 +257,13 @@ export function NotificationSettings({ className = "" }: NotificationSettingsPro
                 <input
                   type="checkbox"
                   checked={quietHoursEnabled}
-                  onChange={(e) => setQuietHoursEnabled(e.target.checked)}
+                  onChange={async (e) => {
+                    setQuietHoursEnabled(e.target.checked);
+                    const quietHours: TimeRange | null = e.target.checked
+                      ? { start: quietStart, end: quietEnd }
+                      : null;
+                    await safeUpdateSettings({ quietHours });
+                  }}
                   className="sr-only peer"
                 />
                 <div className="w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-blue-300 rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-blue-600"></div>
@@ -302,6 +348,38 @@ export function NotificationSettings({ className = "" }: NotificationSettingsPro
                 <option value={50}>50回</option>
               </select>
             </div>
+          </div>
+
+          {/* テスト通知 */}
+          <div className="border-t pt-4">
+            <h3
+              className="text-sm font-medium mb-1"
+              style={{ color: currentTheme.colors.text.primary }}
+            >
+              通知テスト
+            </h3>
+            <p
+              className="text-sm mb-3"
+              style={{ color: currentTheme.colors.text.tertiary }}
+            >
+              通知機能が正常に動作するか確認できます
+            </p>
+            <button
+              onClick={handleTestNotification}
+              disabled={!permission.granted || isSendingTest}
+              className={`px-4 py-2 rounded-md text-sm font-medium ${
+                permission.granted && !isSendingTest
+                  ? 'bg-blue-600 text-white hover:bg-blue-700'
+                  : 'bg-gray-300 text-gray-500 cursor-not-allowed'
+              }`}
+            >
+              {isSendingTest ? '送信中...' : 'テスト通知を送信'}
+            </button>
+            {testMessage && (
+              <div className={`mt-2 text-sm ${testMessage.type === 'success' ? 'text-green-600' : 'text-red-600'}`}>
+                {testMessage.text}
+              </div>
+            )}
           </div>
 
           {/* 音・振動設定 */}

--- a/src/components/recommendation/RecommendationCard.tsx
+++ b/src/components/recommendation/RecommendationCard.tsx
@@ -60,19 +60,21 @@ export const RecommendationCard: React.FC<RecommendationCardProps> = ({
   };
 
   // 日付のフォーマット
-  const formatDate = (date: Date): string => {
+  const formatDate = (date: Date | string): string => {
+    const d = date instanceof Date ? date : new Date(date);
+    if (isNaN(d.getTime())) return '日付不明';
     const today = new Date();
     const tomorrow = new Date(today);
     tomorrow.setDate(tomorrow.getDate() + 1);
 
-    if (date.toDateString() === today.toDateString()) return '今日';
-    if (date.toDateString() === tomorrow.toDateString()) return '明日';
+    if (d.toDateString() === today.toDateString()) return '今日';
+    if (d.toDateString() === tomorrow.toDateString()) return '明日';
 
     return new Intl.DateTimeFormat('ja-JP', {
       month: 'short',
       day: 'numeric',
       weekday: 'short'
-    }).format(date);
+    }).format(d);
   };
 
   return (

--- a/src/components/settings/SettingsPage.tsx
+++ b/src/components/settings/SettingsPage.tsx
@@ -119,7 +119,7 @@ export const SettingsPage: React.FC = () => {
                   OpenWeatherMap API Key
                 </label>
                 <input
-                  type="text"
+                  type="password"
                   id="api-key"
                   value={apiSettings.openWeatherApiKey}
                   onChange={(e) => setApiSettings({ ...apiSettings, openWeatherApiKey: e.target.value })}

--- a/src/components/setup/steps/ApiKeySetupStep.tsx
+++ b/src/components/setup/steps/ApiKeySetupStep.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 
 interface ApiKeySetupStepProps {
   onComplete: () => void;
@@ -6,9 +6,20 @@ interface ApiKeySetupStepProps {
 
 export const ApiKeySetupStep: React.FC<ApiKeySetupStepProps> = ({ onComplete }) => {
   const [apiKey, setApiKey] = useState('');
-  const [isLoading, setIsLoading] = useState(false);
+  const [isTesting, setIsTesting] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState(false);
+  const [testPassed, setTestPassed] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (timerRef.current !== null) {
+        clearTimeout(timerRef.current);
+      }
+    };
+  }, []);
 
   // 既存のAPI Key設定を読み込み
   useEffect(() => {
@@ -34,22 +45,22 @@ export const ApiKeySetupStep: React.FC<ApiKeySetupStepProps> = ({ onComplete }) 
       return;
     }
 
-    setIsLoading(true);
+    setIsSaving(true);
     setError(null);
 
     try {
       // APIキーを保存
       const settings = { openWeatherApiKey: apiKey.trim() };
       localStorage.setItem('hobby-weather-api-settings', JSON.stringify(settings));
-      
+
       // WeatherServiceのAPIキーを更新
       const { weatherService } = await import('../../../services/weather.service');
       weatherService.refreshApiKey();
-      
+
       setSuccess(true);
-      
+
       // 少し待ってから次のステップに進む
-      setTimeout(() => {
+      timerRef.current = setTimeout(() => {
         onComplete();
       }, 1000);
     } catch (error) {
@@ -58,7 +69,7 @@ export const ApiKeySetupStep: React.FC<ApiKeySetupStepProps> = ({ onComplete }) 
       }
       setError('API Keyの保存に失敗しました。もう一度お試しください。');
     } finally {
-      setIsLoading(false);
+      setIsSaving(false);
     }
   };
 
@@ -68,7 +79,7 @@ export const ApiKeySetupStep: React.FC<ApiKeySetupStepProps> = ({ onComplete }) 
       return;
     }
 
-    setIsLoading(true);
+    setIsTesting(true);
     setError(null);
 
     try {
@@ -76,7 +87,7 @@ export const ApiKeySetupStep: React.FC<ApiKeySetupStepProps> = ({ onComplete }) 
       const response = await fetch(
         `https://api.openweathermap.org/data/2.5/weather?q=Tokyo&appid=${apiKey.trim()}&units=metric`
       );
-      
+
       if (!response.ok) {
         if (response.status === 401) {
           throw new Error('API Keyが無効です。正しいキーを入力してください。');
@@ -84,14 +95,14 @@ export const ApiKeySetupStep: React.FC<ApiKeySetupStepProps> = ({ onComplete }) 
           throw new Error('API接続に失敗しました。しばらく時間をおいてから再度お試しください。');
         }
       }
-      
-      setSuccess(true);
+
+      setTestPassed(true);
       setError(null);
     } catch (error) {
       setError(error instanceof Error ? error.message : 'API接続テストに失敗しました');
-      setSuccess(false);
+      setTestPassed(false);
     } finally {
-      setIsLoading(false);
+      setIsTesting(false);
     }
   };
 
@@ -142,10 +153,11 @@ export const ApiKeySetupStep: React.FC<ApiKeySetupStepProps> = ({ onComplete }) 
                 setApiKey(e.target.value);
                 setError(null);
                 setSuccess(false);
+                setTestPassed(false);
               }}
               placeholder="API Keyを入力してください"
               className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-              disabled={isLoading}
+              disabled={isTesting || isSaving}
             />
           </div>
 
@@ -159,12 +171,22 @@ export const ApiKeySetupStep: React.FC<ApiKeySetupStepProps> = ({ onComplete }) 
             </div>
           )}
 
+          {/* Test Success Message */}
+          {testPassed && !success && (
+            <div className="bg-blue-50 border border-blue-200 rounded-md p-3">
+              <div className="flex items-center">
+                <span className="text-blue-400 mr-2">✅</span>
+                <span className="text-sm text-blue-700">API接続テスト成功。「保存して次へ」を押して設定を保存してください。</span>
+              </div>
+            </div>
+          )}
+
           {/* Success Message */}
           {success && (
             <div className="bg-green-50 border border-green-200 rounded-md p-3">
               <div className="flex items-center">
                 <span className="text-green-400 mr-2">✅</span>
-                <span className="text-sm text-green-700">API Keyが正常に設定されました</span>
+                <span className="text-sm text-green-700">API Keyが正常に保存されました</span>
               </div>
             </div>
           )}
@@ -173,18 +195,18 @@ export const ApiKeySetupStep: React.FC<ApiKeySetupStepProps> = ({ onComplete }) 
           <div className="flex space-x-3">
             <button
               onClick={handleTestApiKey}
-              disabled={isLoading || !apiKey.trim()}
+              disabled={isTesting || isSaving || !apiKey.trim()}
               className="flex-1 bg-gray-600 text-white py-2 px-4 rounded-md hover:bg-gray-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
             >
-              {isLoading ? 'テスト中...' : 'API接続テスト'}
+              {isTesting ? 'テスト中...' : 'API接続テスト'}
             </button>
-            
+
             <button
               onClick={handleSaveApiKey}
-              disabled={isLoading || !apiKey.trim()}
+              disabled={isTesting || isSaving || !apiKey.trim()}
               className="flex-1 bg-blue-600 text-white py-2 px-4 rounded-md hover:bg-blue-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
             >
-              {isLoading ? '保存中...' : '保存して次へ'}
+              {isSaving ? '保存中...' : '保存して次へ'}
             </button>
           </div>
         </div>

--- a/src/components/setup/steps/HobbySetupStep.tsx
+++ b/src/components/setup/steps/HobbySetupStep.tsx
@@ -17,8 +17,8 @@ export const HobbySetupStep: React.FC<HobbySetupStepProps> = ({ onComplete, onSk
   }, [hobbies]);
 
   const handleCreateHobby = async (hobbyData: Omit<Hobby, 'id' | 'createdAt' | 'updatedAt'>) => {
-    await createHobby(hobbyData);
-    if (!error) {
+    const success = await createHobby(hobbyData);
+    if (success) {
       setShowForm(false);
     }
   };

--- a/src/components/weather/ForecastCard.tsx
+++ b/src/components/weather/ForecastCard.tsx
@@ -114,7 +114,7 @@ export const ForecastCard: React.FC<ForecastCardProps> = ({
                 <div className="text-center mb-3">
                     <div
                         className={`text-sm font-medium ${getPrecipitationColor(
-                            forecast.pop
+                            Math.round(forecast.pop * 100)
                         )}`}
                     >
                         {Math.round(forecast.pop * 100)}%

--- a/src/components/weather/ForecastList.tsx
+++ b/src/components/weather/ForecastList.tsx
@@ -16,13 +16,16 @@ export const ForecastList: React.FC<ForecastListProps> = ({
     const today = new Date();
     today.setHours(0, 0, 0, 0);
 
-    const formatCacheTime = (date: Date) => {
+    const formatCacheTime = (date: Date | string | null | undefined): string => {
+        if (date == null) return '不明';
+        const d = date instanceof Date ? date : new Date(date);
+        if (isNaN(d.getTime())) return '不明';
         return new Intl.DateTimeFormat('ja-JP', {
             month: 'short',
             day: 'numeric',
             hour: '2-digit',
             minute: '2-digit',
-        }).format(date);
+        }).format(d);
     };
 
     return (

--- a/src/components/weather/WeatherCard.tsx
+++ b/src/components/weather/WeatherCard.tsx
@@ -13,19 +13,23 @@ export const WeatherCard: React.FC<WeatherCardProps> = ({
     className = '',
 }) => {
     const { currentTheme } = useTheme();
-    const formatTime = (date: Date) => {
+    const formatTime = (date: Date | string) => {
+        const d = date instanceof Date ? date : new Date(date);
+        if (isNaN(d.getTime())) return '--:--';
         return new Intl.DateTimeFormat('ja-JP', {
             hour: '2-digit',
             minute: '2-digit',
-        }).format(date);
+        }).format(d);
     };
 
-    const formatDate = (date: Date) => {
+    const formatDate = (date: Date | string) => {
+        const d = date instanceof Date ? date : new Date(date);
+        if (isNaN(d.getTime())) return '日付不明';
         return new Intl.DateTimeFormat('ja-JP', {
             month: 'short',
             day: 'numeric',
             weekday: 'short',
-        }).format(date);
+        }).format(d);
     };
 
     const getWindDirection = (degrees: number): string => {

--- a/src/hooks/useHobby.ts
+++ b/src/hooks/useHobby.ts
@@ -10,8 +10,8 @@ interface UseHobbyState {
 }
 
 interface UseHobbyReturn extends UseHobbyState {
-  createHobby: (hobby: Omit<Hobby, 'id' | 'createdAt' | 'updatedAt'>) => Promise<void>;
-  updateHobby: (id: number, changes: Partial<Hobby>) => Promise<void>;
+  createHobby: (hobby: Omit<Hobby, 'id' | 'createdAt' | 'updatedAt'>) => Promise<boolean>;
+  updateHobby: (id: number, changes: Partial<Hobby>) => Promise<boolean>;
   deleteHobby: (id: number) => Promise<void>;
   toggleHobbyActive: (id: number) => Promise<void>;
   refreshHobbies: () => Promise<void>;
@@ -56,31 +56,35 @@ export const useHobby = (): UseHobbyReturn => {
     }
   }, [updateState]);
 
-  const createHobby = useCallback(async (hobbyData: Omit<Hobby, 'id' | 'createdAt' | 'updatedAt'>) => {
+  const createHobby = useCallback(async (hobbyData: Omit<Hobby, 'id' | 'createdAt' | 'updatedAt'>): Promise<boolean> => {
     updateState({ isLoading: true, error: null });
 
     try {
       await databaseService.createHobby(hobbyData);
       await loadHobbies();
+      return true;
     } catch (error) {
       updateState({
         error: error instanceof Error ? error.message : '趣味の作成に失敗しました',
       });
+      return false;
     } finally {
       updateState({ isLoading: false });
     }
   }, [updateState, loadHobbies]);
 
-  const updateHobby = useCallback(async (id: number, changes: Partial<Hobby>) => {
+  const updateHobby = useCallback(async (id: number, changes: Partial<Hobby>): Promise<boolean> => {
     updateState({ isLoading: true, error: null });
 
     try {
       await databaseService.updateHobby(id, changes);
       await loadHobbies();
+      return true;
     } catch (error) {
       updateState({
         error: error instanceof Error ? error.message : '趣味の更新に失敗しました',
       });
+      return false;
     } finally {
       updateState({ isLoading: false });
     }

--- a/src/hooks/useOnlineStatus.ts
+++ b/src/hooks/useOnlineStatus.ts
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react';
 
 export const useOnlineStatus = () => {
-  const [isOnline, setIsOnline] = useState(navigator.onLine);
+  const [isOnline, setIsOnline] = useState(typeof navigator !== 'undefined' ? navigator.onLine : true);
 
   useEffect(() => {
     const handleOnline = () => setIsOnline(true);

--- a/src/services/notification.service.ts
+++ b/src/services/notification.service.ts
@@ -73,6 +73,8 @@ export class NotificationService {
 
   // 通知送信
   async sendNotification(payload: NotificationPayload): Promise<boolean> {
+    // リアルタイムの権限状態を取得して同期
+    this.permission = this.getPermissionState();
     if (!this.permission.granted) {
       if (import.meta.env.DEV) {
         console.warn('通知権限が許可されていません');


### PR DESCRIPTION
## 修正 Issue 一覧

- Closes #50
- Closes #51
- Closes #52
- Closes #66
- Closes #67
- Closes #78
- Closes #80
- Closes #88
- Closes #94
- Closes #104
- Closes #112
- Closes #113
- Closes #125
- Closes #130
- Closes #147
- Closes #155
- Closes #156
- Closes #157
- Closes #159
- Closes #165
- Closes #167
- Closes #170

## 修正内容

- #50: 通知権限のリアルタイム同期
- #51: テスト通知UIにフィードバック追加
- #52: 通知設定画面にテスト機能追加
- #66: ESLint globals設定追加
- #67: ESLint定数化改善
- #78: browserslist設定追加
- #80: lazy import用ErrorBoundary追加
- #88: APIキープレビューの本番非表示
- #94: hobby.idの安全なnullガード
- #104: createHobby/updateHobbyのboolean戻り値対応
- #112: 通知設定ハンドラーのエラーハンドリング
- #113: 静寂時間トグルOFF時の保存処理修正
- #125: 日付系関数のstring型対応
- #130: navigator.onLineの環境チェック
- #147: APIキー入力のtype=password化
- #155: APIKeySetupStep改善
- #156: APIKeySetupStep改善（続き）
- #157: HobbySetupStep改善
- #159: SetupStep改善
- #165: 降水確率のスケール不一致修正
- #167: 日付系関数のstring型対応（続き）
- #170: 日付系関数のstring型対応（続き）

## テスト

- ビルド: 全修正後にビルド検証済み